### PR TITLE
Add files via upload

### DIFF
--- a/lib/domains/nz/school/karamu.txt
+++ b/lib/domains/nz/school/karamu.txt
@@ -1,0 +1,1 @@
+Karamu High School


### PR DESCRIPTION
Karamu High School uses two domains, karamu.nz for students already added, karamu.school.nz for faculty staff (this request)

[Senior Course Booklet](https://karamu.ibcdn.nz/media/2023_09_15_senior-course-booklet-2024.pdf)
Page 12 shows 3 years of Computer Science (Digital Technologies) or Computing Applications.
(PDF link valid for 2024)